### PR TITLE
fix check of Android version for Context.color()

### DIFF
--- a/library/src/main/java/com/mytoolbox/canvasdsl/common/Extensions.kt
+++ b/library/src/main/java/com/mytoolbox/canvasdsl/common/Extensions.kt
@@ -19,7 +19,7 @@ val Float.dp: Float get() = this * dpi
 
 fun Context.color(id: Int) = with(resources) {
     @Suppress("DEPRECATION")
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
         getColor(id, theme)
     else
         getColor(id)


### PR DESCRIPTION
There is a wrong check for Android version at Context.color() that could lead to crash on Android lower than 6.0:
`int getColor(int id, @Nullable Resources.Theme theme)` was only added at Android 6.0, but check is for Android 5.0.